### PR TITLE
Add Smithery CLI Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
+No such line 9 in input file, ignoring
 # YouTube MCP Server
+
+[![smithery badge](https://smithery.ai/badge/@anaisbetts/mcp-youtube)](https://smithery.ai/protocol/@anaisbetts/mcp-youtube)
 
 Uses `yt-dlp` to download subtitles from YouTube and connects it to claude.ai via [Model Context Protocol](https://modelcontextprotocol.io/introduction). Try it by asking Claude, "Summarize the YouTube video <<URL>>". Requires `yt-dlp` to be installed locally e.g. via Homebrew.
 
 ### How do I get this working?
 
+### Installing via Smithery
+
+To install YouTube MCP for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/@anaisbetts/mcp-youtube):
+
+```bash
+npx @smithery/cli install @anaisbetts/mcp-youtube --client claude
+```
+
 1. Install `yt-dlp` (Homebrew and WinGet both work great here)
-1. Now, install this via [mcp-installer](https://github.com/anaisbetts/mcp-installer), use the name `@anaisbetts/mcp-youtube`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-No such line 9 in input file, ignoring
 # YouTube MCP Server
 
 [![smithery badge](https://smithery.ai/badge/@anaisbetts/mcp-youtube)](https://smithery.ai/protocol/@anaisbetts/mcp-youtube)
@@ -7,7 +6,7 @@ Uses `yt-dlp` to download subtitles from YouTube and connects it to claude.ai vi
 
 ### How do I get this working?
 
-### Installing via Smithery
+#### Installing via Smithery
 
 To install YouTube MCP for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/@anaisbetts/mcp-youtube):
 


### PR DESCRIPTION
This PR adds installation instructions to automatically install YouTube MCP for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP. Also, it adds a badge to show the number of installations from Smithery.