### PR TITLE
feat: support customized args for yt-dlp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@anaisbetts/mcp-youtube",
   "version": "0.6.0",
+  "type": "module",
   "bin": {
     "mcp-youtube": "lib/index.mjs"
   },


### PR DESCRIPTION
Support customizable arguments for yt-dlp, which can be passed via the --args parameter during invocation. This enables users to configure yt-dlp with greater flexibility, such as utilizing proxies or incorporating their own cookies.